### PR TITLE
Adiciona geração de DANFE em modo pré-visualização

### DIFF
--- a/src/Vip.DFe.Demo/frmPrincipal.cs
+++ b/src/Vip.DFe.Demo/frmPrincipal.cs
@@ -341,7 +341,7 @@ namespace Vip.DFe.Demo
 
         private void FuncaoGerarDanfe()
         {
-            if (txtXml.Text.IsNullOrEmpty()) txtParametro.Text = ObterCaminhoArquivo();
+            if (txtXml.Text.IsNullOrEmpty() && txtParametro.Text.IsNullOrEmpty()) txtParametro.Text = ObterCaminhoArquivo();
 
             if (txtXml.Text.IsNullOrEmpty() && txtParametro.Text.IsNullOrEmpty())
             {

--- a/src/Vip.DFe.Tests/Danfe/DanfeViewModelCreatorTests.cs
+++ b/src/Vip.DFe.Tests/Danfe/DanfeViewModelCreatorTests.cs
@@ -1,0 +1,228 @@
+using System;
+using System.IO;
+using Vip.DFe.Danfe;
+using Vip.DFe.Danfe.Modelo;
+using Xunit;
+
+namespace Vip.DFe.Tests.Danfe
+{
+    public class DanfeViewModelCreatorTests
+    {
+        private const string ChaveAcesso = "35160810873538000245550010000000111504749126";
+
+        [Fact]
+        public void DanfeViewModelCreator_CriarDoConteudoXml_ComNFeProc_DeveManterFluxoAtual()
+        {
+            var model = DanfeViewModel.CriarDoConteudoXml(ObterNFeProcXml());
+
+            Assert.False(model.ModoEspelho);
+            Assert.Equal("135260000000000 - 26/03/2026 10:15:00", model.ProtocoloAutorizacao);
+            Assert.Equal(100, model.CodigoStatusReposta);
+            Assert.Equal("Autorizado o uso da NF-e", model.DescricaoStatusReposta);
+            Assert.Equal(ChaveAcesso, model.ChaveAcesso);
+        }
+
+        [Fact]
+        public void DanfeViewModelCreator_CriarDoConteudoXml_ComNFe_DeveGerarModoEspelho()
+        {
+            var model = DanfeViewModel.CriarDoConteudoXml(ObterNFeXml());
+
+            Assert.True(model.ModoEspelho);
+            Assert.Null(model.ProtocoloAutorizacao);
+            Assert.Null(model.CodigoStatusReposta);
+            Assert.Null(model.DescricaoStatusReposta);
+            Assert.Equal(ChaveAcesso, model.ChaveAcesso);
+            Assert.Equal("EMITENTE TESTE LTDA", model.Emitente.RazaoSocial);
+            Assert.Equal("DESTINATARIO TESTE LTDA", model.Destinatario.RazaoSocial);
+            Assert.Single(model.Produtos);
+            Assert.Equal(100D, model.CalculoImposto.ValorTotalNota);
+        }
+
+        [Fact]
+        public void DanfeService_Gerar_ComModeloEspelho_DeveConcluirSemErro()
+        {
+            var model = DanfeViewModel.CriarDoConteudoXml(ObterNFeXml());
+
+            using var danfe = new DanfeService(model);
+            using var stream = new MemoryStream();
+
+            danfe.Gerar();
+            danfe.Salvar(stream);
+
+            Assert.True(stream.Length > 0);
+        }
+
+        [Fact]
+        public void DanfeViewModelCreator_CriarDoConteudoXml_ComRaizNaoSuportada_DeveRetornarMensagemClara()
+        {
+            var exception = Assert.Throws<System.Exception>(() => DanfeViewModel.CriarDoConteudoXml(@"<foo />"));
+
+            Assert.Contains("Documento raiz 'foo' não suportado para geração da DANFE.", exception.Message);
+        }
+
+        private static string ObterNFeXml(bool incluirDeclaracao = true)
+        {
+            var xml = $@"
+<NFe xmlns=""http://www.portalfiscal.inf.br/nfe"">
+  <infNFe versao=""4.00"" Id=""NFe{ChaveAcesso}"">
+    <ide>
+      <cUF>35</cUF>
+      <cNF>50474912</cNF>
+      <natOp>VENDA DE MERCADORIA</natOp>
+      <mod>55</mod>
+      <serie>1</serie>
+      <nNF>11</nNF>
+      <dhEmi>2016-08-01T10:00:00-03:00</dhEmi>
+      <tpNF>1</tpNF>
+      <idDest>1</idDest>
+      <cMunFG>3550308</cMunFG>
+      <tpImp>1</tpImp>
+      <tpEmis>1</tpEmis>
+      <cDV>6</cDV>
+      <tpAmb>1</tpAmb>
+      <finNFe>1</finNFe>
+      <indFinal>1</indFinal>
+      <indPres>1</indPres>
+      <procEmi>0</procEmi>
+      <verProc>1.0.0</verProc>
+    </ide>
+    <emit>
+      <CNPJ>10873538000245</CNPJ>
+      <xNome>EMITENTE TESTE LTDA</xNome>
+      <xFant>EMITENTE TESTE</xFant>
+      <enderEmit>
+        <xLgr>RUA TESTE</xLgr>
+        <nro>100</nro>
+        <xBairro>CENTRO</xBairro>
+        <cMun>3550308</cMun>
+        <xMun>SAO PAULO</xMun>
+        <UF>SP</UF>
+        <CEP>01001000</CEP>
+        <cPais>1058</cPais>
+        <xPais>BRASIL</xPais>
+        <fone>1133334444</fone>
+      </enderEmit>
+      <IE>123456789</IE>
+      <CRT>3</CRT>
+    </emit>
+    <dest>
+      <CNPJ>27076697000130</CNPJ>
+      <xNome>DESTINATARIO TESTE LTDA</xNome>
+      <enderDest>
+        <xLgr>AV DESTINO</xLgr>
+        <nro>200</nro>
+        <xBairro>BAIRRO</xBairro>
+        <cMun>3550308</cMun>
+        <xMun>SAO PAULO</xMun>
+        <UF>SP</UF>
+        <CEP>02002000</CEP>
+        <cPais>1058</cPais>
+        <xPais>BRASIL</xPais>
+        <fone>1144445555</fone>
+      </enderDest>
+      <indIEDest>9</indIEDest>
+      <email>destinatario@teste.com.br</email>
+    </dest>
+    <det nItem=""1"">
+      <prod>
+        <cProd>001</cProd>
+        <cEAN>SEM GTIN</cEAN>
+        <xProd>PRODUTO TESTE</xProd>
+        <NCM>84713012</NCM>
+        <CFOP>5102</CFOP>
+        <uCom>UN</uCom>
+        <qCom>1.0000</qCom>
+        <vUnCom>100.0000</vUnCom>
+        <vProd>100.00</vProd>
+        <cEANTrib>SEM GTIN</cEANTrib>
+        <uTrib>UN</uTrib>
+        <qTrib>1.0000</qTrib>
+        <vUnTrib>100.0000</vUnTrib>
+        <indTot>1</indTot>
+      </prod>
+      <imposto>
+        <vTotTrib>20.00</vTotTrib>
+        <ICMS>
+          <ICMS00>
+            <orig>0</orig>
+            <CST>00</CST>
+            <modBC>3</modBC>
+            <vBC>100.00</vBC>
+            <pICMS>18.00</pICMS>
+            <vICMS>18.00</vICMS>
+          </ICMS00>
+        </ICMS>
+        <PIS>
+          <PISNT>
+            <CST>07</CST>
+          </PISNT>
+        </PIS>
+        <COFINS>
+          <COFINSNT>
+            <CST>07</CST>
+          </COFINSNT>
+        </COFINS>
+      </imposto>
+      <infAdProd>DETALHE ADICIONAL</infAdProd>
+    </det>
+    <total>
+      <ICMSTot>
+        <vBC>100.00</vBC>
+        <vICMS>18.00</vICMS>
+        <vICMSDeson>0.00</vICMSDeson>
+        <vFCP>0.00</vFCP>
+        <vBCST>0.00</vBCST>
+        <vST>0.00</vST>
+        <vFCPST>0.00</vFCPST>
+        <vFCPSTRet>0.00</vFCPSTRet>
+        <vProd>100.00</vProd>
+        <vFrete>0.00</vFrete>
+        <vSeg>0.00</vSeg>
+        <vDesc>0.00</vDesc>
+        <vII>0.00</vII>
+        <vIPI>0.00</vIPI>
+        <vIPIDevol>0.00</vIPIDevol>
+        <vPIS>0.00</vPIS>
+        <vCOFINS>0.00</vCOFINS>
+        <vOutro>0.00</vOutro>
+        <vNF>100.00</vNF>
+        <vTotTrib>20.00</vTotTrib>
+      </ICMSTot>
+    </total>
+    <transp>
+      <modFrete>9</modFrete>
+    </transp>
+    <infAdic>
+      <infCpl>OBS TESTE</infCpl>
+      <infAdFisco>FISCO TESTE</infAdFisco>
+    </infAdic>
+  </infNFe>
+</NFe>";
+
+            if (incluirDeclaracao)
+                return "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + xml;
+
+            return xml;
+        }
+
+        private static string ObterNFeProcXml()
+        {
+            return $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<nfeProc xmlns=""http://www.portalfiscal.inf.br/nfe"" versao=""4.00"">
+  {ObterNFeXml(false)}
+  <protNFe versao=""4.00"">
+    <infProt>
+      <tpAmb>1</tpAmb>
+      <verAplic>SVRS202600000000</verAplic>
+      <chNFe>{ChaveAcesso}</chNFe>
+      <dhRecbto>2026-03-26T10:15:00-03:00</dhRecbto>
+      <nProt>135260000000000</nProt>
+      <digVal>AAAAAAAAAAAAAAAAAAAAAAAAAAAA</digVal>
+      <cStat>100</cStat>
+      <xMotivo>Autorizado o uso da NF-e</xMotivo>
+    </infProt>
+  </protNFe>
+</nfeProc>";
+        }
+    }
+}

--- a/src/Vip.DFe/0-Domain/Danfe/Blocos/BlocoIdentificacaoEmitente.cs
+++ b/src/Vip.DFe/0-Domain/Danfe/Blocos/BlocoIdentificacaoEmitente.cs
@@ -20,6 +20,8 @@ namespace Vip.DFe.Danfe.Blocos
 
         public BlocoIdentificacaoEmitente(DanfeViewModel viewModel, Estilo estilo) : base(viewModel, estilo)
         {
+            var protocoloAutorizacao = ViewModel.ModoEspelho ? "SEM PROTOCOLO - PRÉ VISUALIZAÇÃO" : ViewModel.ProtocoloAutorizacao;
+
             var textoConsulta = new TextoSimples(Estilo, DanfeConstantes.TextoConsulta)
             {
                 Height = 8,
@@ -47,7 +49,7 @@ namespace Vip.DFe.Danfe.Blocos
 
             AdicionarLinhaCampos()
                 .ComCampo("Natureza da operação", ViewModel.NaturezaOperacao)
-                .ComCampo("Protocolo de autorização", ViewModel.ProtocoloAutorizacao, AlinhamentoHorizontal.Centro)
+                .ComCampo("Protocolo de autorização", protocoloAutorizacao, AlinhamentoHorizontal.Centro)
                 .ComLarguras(0, 46.5F);
 
             AdicionarLinhaCampos()

--- a/src/Vip.DFe/0-Domain/Danfe/Modelo/DanfeViewModel.cs
+++ b/src/Vip.DFe/0-Domain/Danfe/Modelo/DanfeViewModel.cs
@@ -154,6 +154,11 @@ namespace Vip.DFe.Danfe.Modelo
         public string ProtocoloAutorizacao { get; set; }
 
         /// <summary>
+        ///     Indica que o DANFE foi gerado a partir de um XML sem protocolo de autorização.
+        /// </summary>
+        public bool ModoEspelho { get; set; }
+
+        /// <summary>
         ///     Faturas da Nota Fiscal
         /// </summary>
         public List<DuplicataViewModel> Duplicatas { get; set; }

--- a/src/Vip.DFe/0-Domain/Danfe/Modelo/DanfeViewModelCreator.cs
+++ b/src/Vip.DFe/0-Domain/Danfe/Modelo/DanfeViewModelCreator.cs
@@ -15,7 +15,9 @@ using Vip.DFe.NFe.NotaFiscal.Detalhe.Imposto.Estadual;
 using Vip.DFe.NFe.NotaFiscal.Detalhe.Imposto.Federal;
 using Vip.DFe.NFe.NotaFiscal.Emitente;
 using Vip.DFe.NFe.NotaFiscal.Total;
+using Vip.DFe.NFe.Protocolo;
 using Vip.DFe.Shared.Enum;
+using NFeNotaFiscal = Vip.DFe.NFe.NotaFiscal.NFe;
 
 namespace Vip.DFe.Danfe.Modelo
 {
@@ -38,12 +40,12 @@ namespace Vip.DFe.Danfe.Modelo
         {
             try
             {
-                var nfe = NFeProc.Load(stream);
-                return CreateFromXml(nfe);
+                return CreateFromXmlContent(ReadXmlContent(stream));
             }
             catch (System.Exception ex)
             {
-                if (ex.InnerException is XmlException e) throw new System.Exception($"Não foi possível interpretar o Xml. Linha {e.LineNumber} Posição {e.LinePosition}.");
+                if (ex is XmlException xmlException) throw new System.Exception($"Não foi possível interpretar o Xml. Linha {xmlException.LineNumber} Posição {xmlException.LinePosition}.", ex);
+                if (ex.InnerException is XmlException e) throw new System.Exception($"Não foi possível interpretar o Xml. Linha {e.LineNumber} Posição {e.LinePosition}.", ex);
                 throw new XmlException($"Não foi possível processar o XML da NF-e.\r\n\r\nMensagem: {ex.Message}", ex);
             }
         }
@@ -52,8 +54,11 @@ namespace Vip.DFe.Danfe.Modelo
         {
             try
             {
-                var nfe = NFeProc.Load(xml);
-                return CreateFromXml(nfe);
+                return CreateFromXmlContent(xml);
+            }
+            catch (XmlException ex)
+            {
+                throw new System.Exception($"Não foi possível interpretar o texto Xml. {ex.Message}", ex);
             }
             catch (System.Exception ex)
             {
@@ -94,12 +99,27 @@ namespace Vip.DFe.Danfe.Modelo
 
         public static DanfeViewModel CreateFromXml(NFeProc procNfe)
         {
+            if (procNfe == null) throw new ArgumentNullException(nameof(procNfe));
+
+            return CreateFromXml(procNfe.NFe, procNfe.ProtNFe?.InfProt);
+        }
+
+        internal static DanfeViewModel CreateFromXml(NFeNotaFiscal nfe)
+        {
+            if (nfe == null) throw new ArgumentNullException(nameof(nfe));
+
+            return CreateFromXml(nfe, null);
+        }
+
+        private static DanfeViewModel CreateFromXml(NFeNotaFiscal nfe, NFeInfProt infProt)
+        {
             var model = new DanfeViewModel();
 
-            var nfe = procNfe.NFe;
             var infNfe = nfe.InfNFe;
             var ide = infNfe.Ide;
+            var modoEspelho = infProt == null;
 
+            model.ModoEspelho = modoEspelho;
             model.TipoEmissao = ide.TipoEmissao;
 
             if (ide.Modelo != NFeModelo.NFe)
@@ -110,14 +130,17 @@ namespace Vip.DFe.Danfe.Modelo
 
             model.Orientacao = ide.TipoImpressao == TipoImpressao.NormalRetrato ? Orientacao.Retrato : Orientacao.Paisagem;
 
-            var infProt = procNfe.ProtNFe.InfProt;
-            model.CodigoStatusReposta = infProt.CStat;
-            model.DescricaoStatusReposta = infProt.Motivo;
+            if (infProt != null)
+            {
+                model.CodigoStatusReposta = infProt.CStat;
+                model.DescricaoStatusReposta = infProt.Motivo;
+            }
+
             model.TipoAmbiente = (int) ide.TpAmb;
             model.NfNumero = (int) ide.NumeroNFe;
             model.NfSerie = ide.Serie;
             model.NaturezaOperacao = ide.NatOp;
-            model.ChaveAcesso = procNfe.NFe.InfNFe.Id.Substring(3);
+            model.ChaveAcesso = nfe.InfNFe.Id.Substring(3);
             model.TipoNF = (int) ide.TipoNFe;
 
             model.Emitente = ObterEmitente(infNfe.Emitente);
@@ -260,14 +283,15 @@ namespace Vip.DFe.Danfe.Modelo
             var infAdic = infNfe.InformacaoAdicional;
             if (infAdic != null)
             {
-                model.InformacoesComplementares = procNfe.NFe.InfNFe.InformacaoAdicional.InformacaoComplementar;
-                model.InformacoesAdicionaisFisco = procNfe.NFe.InfNFe.InformacaoAdicional.InformacaoFisco;
+                model.InformacoesComplementares = infAdic.InformacaoComplementar;
+                model.InformacoesAdicionaisFisco = infAdic.InformacaoFisco;
             }
 
             #endregion
 
-            var infoProt = procNfe.ProtNFe.InfProt;
-            model.ProtocoloAutorizacao = string.Format(DanfeHelper.Cultura, "{0} - {1}", infoProt.NProt, infoProt.DhRecbto.DateTime);
+            if (infProt != null)
+                model.ProtocoloAutorizacao = string.Format(DanfeHelper.Cultura, "{0} - {1}", infProt.NProt, infProt.DhRecbto.DateTime);
+
             model.DataHoraEmissao = ide.DhEmi.DateTime;
             model.DataSaidaEntrada = ide.DhSaiEnt?.DateTime;
 
@@ -287,6 +311,53 @@ namespace Vip.DFe.Danfe.Modelo
         #endregion
 
         #region Private methods
+
+        private static DanfeViewModel CreateFromXmlContent(string xml)
+        {
+            var rootName = GetXmlRootName(xml);
+
+            switch (rootName)
+            {
+                case "nfeProc":
+                    return CreateFromXml(NFeProc.Load(xml));
+                case "NFe":
+                    return CreateFromXml(NFeNotaFiscal.Load(xml));
+                default:
+                    throw new XmlException($"Documento raiz '{rootName}' não suportado para geração da DANFE.");
+            }
+        }
+
+        private static string ReadXmlContent(Stream stream)
+        {
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+            if (stream.CanSeek) stream.Position = 0;
+
+            using (var reader = new StreamReader(stream, Encoding.UTF8, true, 1024, true))
+            {
+                var xml = reader.ReadToEnd();
+                if (stream.CanSeek) stream.Position = 0;
+                return xml;
+            }
+        }
+
+        private static string GetXmlRootName(string xml)
+        {
+            if (string.IsNullOrWhiteSpace(xml))
+                throw new XmlException("O conteúdo Xml não foi informado.");
+
+            var settings = new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Prohibit,
+                IgnoreWhitespace = true
+            };
+
+            using (var stringReader = new StringReader(xml))
+            using (var reader = XmlReader.Create(stringReader, settings))
+            {
+                reader.MoveToContent();
+                return reader.LocalName;
+            }
+        }
 
         private static EmpresaViewModel ObterEmitente(NFeEmit emit)
         {

--- a/src/Vip.DFe/1-Services/Danfe/DanfePagina.cs
+++ b/src/Vip.DFe/1-Services/Danfe/DanfePagina.cs
@@ -68,11 +68,18 @@ namespace Vip.DFe.Danfe
             Gfx.Flush();
         }
 
-        public void DesenharAvisoHomologacao()
+        public void DesenharAviso(params string[] linhas)
         {
-            TextStack ts = new TextStack(RetanguloCorpo) {AlinhamentoVertical = AlinhamentoVertical.Centro, AlinhamentoHorizontal = AlinhamentoHorizontal.Centro, LineHeightScale = 0.9F}
-                .AddLine("SEM VALOR FISCAL", Danfe.EstiloPadrao.CriarFonteRegular(48))
-                .AddLine("AMBIENTE DE HOMOLOGAÇÃO", Danfe.EstiloPadrao.CriarFonteRegular(30));
+            if (linhas == null || linhas.Length == 0) return;
+
+            var tamanhosFonte = ObterTamanhosFonteAviso(linhas.Length);
+            var ts = new TextStack(RetanguloCorpo) {AlinhamentoVertical = AlinhamentoVertical.Centro, AlinhamentoHorizontal = AlinhamentoHorizontal.Centro, LineHeightScale = 0.9F};
+
+            for (int i = 0; i < linhas.Length; i++)
+            {
+                var indiceFonte = i < tamanhosFonte.Length ? i : tamanhosFonte.Length - 1;
+                ts.AddLine(linhas[i], Danfe.EstiloPadrao.CriarFonteRegular(tamanhosFonte[indiceFonte]));
+            }
 
             Gfx.PrimitiveComposer.BeginLocalState();
             Gfx.PrimitiveComposer.SetFillColor(new DeviceRGBColor(0.35, 0.35, 0.35));
@@ -148,6 +155,13 @@ namespace Vip.DFe.Danfe
                 Gfx.PrimitiveComposer.End();
                 RetanguloDesenhavel = RetanguloDesenhavel.CutLeft(canhoto.Height * Danfe.ViewModel.QuantidadeCanhotos);
             }
+        }
+
+        private static float[] ObterTamanhosFonteAviso(int quantidadeLinhas)
+        {
+            if (quantidadeLinhas <= 1) return new[] {48F};
+            if (quantidadeLinhas == 2) return new[] {48F, 30F};
+            return new[] {38F, 30F, 24F};
         }
 
         #endregion

--- a/src/Vip.DFe/1-Services/Danfe/DanfeService.cs
+++ b/src/Vip.DFe/1-Services/Danfe/DanfeService.cs
@@ -181,10 +181,27 @@ namespace Vip.DFe.Danfe
             page.DesenharBlocos(Paginas.Count == 1);
             page.DesenharCreditos();
 
-            if (ViewModel.TipoAmbiente == 2)
-                page.DesenharAvisoHomologacao();
+            var linhasAviso = ObterLinhasAviso();
+            if (linhasAviso.Length > 0)
+                page.DesenharAviso(linhasAviso);
 
             return page;
+        }
+
+        private string[] ObterLinhasAviso()
+        {
+            if (ViewModel.ModoEspelho)
+            {
+                if (ViewModel.TipoAmbiente == 2)
+                    return new[] { "DANFE EM PRÉ-VISUALIZAÇÃO", "SEM AUTORIZAÇÃO DE USO", "AMBIENTE DE HOMOLOGAÇÃO"};
+
+                return new[] { "DANFE EM PRÉ-VISUALIZAÇÃO", "SEM AUTORIZAÇÃO DE USO"};
+            }
+
+            if (ViewModel.TipoAmbiente == 2)
+                return new[] {"SEM VALOR FISCAL", "AMBIENTE DE HOMOLOGAÇÃO"};
+
+            return Array.Empty<string>();
         }
 
         private void AdicionarMetadata()


### PR DESCRIPTION
## Título

feat: Implementa geração de DANFE em modo espelho a partir de XML NFe

## Resumo

Esta Pull Request introduz a capacidade de gerar o DANFE a partir de um XML da NFe que não contém o protocolo de autorização (nfeProc). O novo "Modo Espelho" permite a pré-visualização do DANFE mesmo antes da autorização da nota, exibindo avisos claros sobre a ausência de valor fiscal.

## Mudanças Realizadas

* Adicionada a propriedade `ModoEspelho` ao `DanfeViewModel` para indicar se o DANFE foi gerado sem protocolo.
* Refatorado `DanfeViewModelCreator` para identificar o elemento raiz do XML (`nfeProc` ou `NFe`) e criar o modelo DANFE adequadamente.
* Implementada lógica para exibir "SEM PROTOCOLO - PRÉ VISUALIZAÇÃO" no campo de protocolo quando em modo espelho.
* Aprimorada a função de desenho de avisos (`DesenharAviso`) para aceitar múltiplas linhas e ajustar o tamanho da fonte dinamicamente.
* Adicionados avisos específicos no DANFE para o modo espelho, como "DANFE EM PRÉ-VISUALIZAÇÃO" e "SEM AUTORIZAÇÃO DE USO", combinados com o aviso de homologação quando aplicável.
* Incluídos testes unitários abrangentes para o `DanfeViewModelCreator`, cobrindo a criação de modelos a partir de XMLs `nfeProc` e `NFe`, e a geração do DANFE em modo espelho.
* Ajuste na aplicação demo para permitir a geração do DANFE a partir de um arquivo XML `NFe` sem protocolo.

## Como Testar

1. Compile e execute o projeto `Vip.DFe.Demo`.
2. Na tela principal, selecione a aba "DANFE".
3. *Teste com XML `nfeProc` (fluxo existente):*
3.1. No campo "Parâmetro", informe o caminho para um arquivo XML de NFe *já autorizado* (com `nfeProc`).
3.2. Clique em "Gerar DANFE".
3.3. Verifique se o DANFE é gerado corretamente, exibindo o protocolo de autorização e, se for ambiente de homologação, o aviso "SEM VALOR FISCAL".
4. *Teste com XML `NFe` (novo modo espelho):*
4.1. No campo "Parâmetro", informe o caminho para um arquivo XML de NFe *sem o protocolo de autorização* (apenas o elemento `<NFe>`). Um exemplo pode ser um XML de NFe antes de ser assinado e transmitido.
4.2. Clique em "Gerar DANFE".
4.3. Verifique se o DANFE é gerado, exibindo "SEM PROTOCOLO - PRÉ VISUALIZAÇÃO" no campo de protocolo.
4.4. Confirme que os avisos "DANFE EM PRÉ-VISUALIZAÇÃO" e "SEM AUTORIZAÇÃO DE USO" são exibidos sobre o DANFE. Se o ambiente for de homologação, o aviso "AMBIENTE DE HOMOLOGAÇÃO" também deve aparecer.
5. Execute os testes unitários do projeto `Vip.DFe.Tests` para garantir que todos os cenários, incluindo a criação de modelos e a geração de DANFE em modo espelho, passem com sucesso.

## Notas para o Revisor

* A detecção do modo espelho é baseada na presença do elemento `protNFe` no XML. Se o XML raiz for `NFe`, assume-se o modo espelho.
* A lógica de ajuste de fonte para os avisos foi implementada em `DanfePagina.ObterTamanhosFonteAviso` para lidar com diferentes quantidades de linhas de aviso de forma flexível.
* A manipulação de exceções de XML foi aprimorada para fornecer mensagens mais claras, incluindo linha e posição do erro.