### PR TITLE
Altera tipo de DCompet para DateTime e remove ShouldSerializeDCompet

### DIFF
--- a/src/Vip.DFe/0-Domain/NFe/NotaFiscal/Total/NFeIssqnTot.cs
+++ b/src/Vip.DFe/0-Domain/NFe/NotaFiscal/Total/NFeIssqnTot.cs
@@ -1,7 +1,7 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using Vip.DFe.Attributes;
 using Vip.DFe.Enum;
-using Vip.DFe.Extensions;
 using Vip.DFe.Serializer;
 using Vip.DFe.Shared.Enum;
 
@@ -54,7 +54,7 @@ namespace Vip.DFe.NFe.NotaFiscal.Total
         ///     W22a - Data da prestação do serviço
         /// </summary>
         [DFeElement(TipoCampo.Dat, "dCompet", Id = "W22a", Min = 10, Max = 10, Ocorrencia = Ocorrencia.Obrigatoria)]
-        public string DCompet { get; set; }
+        public DateTime DCompet { get; set; }
 
         /// <summary>
         ///     W22b - Valor total dedução para redução da Base de Cálculo
@@ -95,11 +95,6 @@ namespace Vip.DFe.NFe.NotaFiscal.Total
         #endregion
 
         #region Methods
-
-        private bool ShouldSerializeDCompet()
-        {
-            return DCompet.IsNotNullOrEmpty();
-        }
 
         private bool ShouldSerializeCRegTrib()
         {


### PR DESCRIPTION
## Título

fix: alterar tipo de DCompet para DateTime e remover código obsoleto

## Resumo

Esta alteração substitui a propriedade DCompet de string para DateTime na classe NFeIssqnTot, proporcionando maior segurança de tipo e facilitando o manuseio de datas. Também remove o using não utilizado Vip.DFe.Extensions e o método de serialização condicional ShouldSerializeDCompet, já não necessário com o novo tipo.

## Mudanças Realizadas

* Adicionado `using System;` e mantido `using System.ComponentModel;`
* Removido `using Vip.DFe.Extensions;`
* Alterado o tipo da propriedade `DCompet` de `string` para `DateTime`
* Removido o método privado `ShouldSerializeDCompet()`

## Como Testar

1. Compilar a solução para garantir que não há erros de compilação.
2. Executar os testes unitários existentes que envolvem a classe `NFeIssqnTot` e validar que eles continuam passando.
3. Criar um teste de serialização que preencha `DCompet` com um `DateTime` e verifique se o XML gerado contém o elemento `<dCompet>` no formato `yyyy-MM-dd`.
4. Verificar que a remoção do `ShouldSerializeDCompet` não afeta a serialização quando a propriedade tem seu valor padrão (`DateTime.MinValue`).

## Notas para o Revisor

* A mudança de `string` para `DateTime` pressupõe que o consumidor da classe agora forneça ou leia um valor `DateTime`; códigos que atribuíam strings diretamente precisarão ser atualizados.
* O atributo `DFeElement` com `TipoCampo.Dat` já espera uma data; o serializer da Vip.DFe deve lidar corretamente com a conversão de `DateTime` para o formato esperado.
* Como `DateTime` é um tipo não anulável, o valor padrão será `DateTime.MinValue` (0001-01-01); caso isso seja indesejado, pode ser necessário tornar a propriedade anulável (`DateTime?`) e ajustar o atributo de ocorrência, mas isso foge ao escopo deste hotfix.
* Nenhum outro arquivo foi modificado; portanto, o impacto é limitado a este módulo.